### PR TITLE
added checks for all parts in the 168's family

### DIFF
--- a/serial_device.h
+++ b/serial_device.h
@@ -72,7 +72,7 @@ uint8_t serialBits[UART_COUNT][UART_BITS] = {{
  
 #elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) \
     || defined(__AVR_ATmega48__) || defined(__AVR_ATmega88__) \
-    defined(__AVR_ATmega168P__) || defined(__AVR_ATmega328P__) \
+    || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega328P__) \
     || defined(__AVR_ATmega48P__) || defined(__AVR_ATmega88P__) 
 
 #define UART_COUNT 1

--- a/serial_device.h
+++ b/serial_device.h
@@ -70,7 +70,8 @@ uint8_t serialBits[UART_COUNT][UART_BITS] = {{
 #define SERIALRECIEVEINTERRUPT USART_RXC_vect
 #define SERIALTRANSMITINTERRUPT USART_UDRE_vect
 
-#elif defined(__AVR_ATmega168__)
+#elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) \
+    || defined(__AVR_ATmega48__) || defined(__AVR_ATmega88__)
 
 #define UART_COUNT 1
 #define UART_REGISTERS 5

--- a/serial_device.h
+++ b/serial_device.h
@@ -69,9 +69,11 @@ uint8_t serialBits[UART_COUNT][UART_BITS] = {{
 }};
 #define SERIALRECIEVEINTERRUPT USART_RXC_vect
 #define SERIALTRANSMITINTERRUPT USART_UDRE_vect
-
+ 
 #elif defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) \
-    || defined(__AVR_ATmega48__) || defined(__AVR_ATmega88__)
+    || defined(__AVR_ATmega48__) || defined(__AVR_ATmega88__) \
+    defined(__AVR_ATmega168P__) || defined(__AVR_ATmega328P__) \
+    || defined(__AVR_ATmega48P__) || defined(__AVR_ATmega88P__) 
 
 #define UART_COUNT 1
 #define UART_REGISTERS 5


### PR DESCRIPTION
328, 44, and 88 only differ from the 168 in memory and vector size and boot loader sections.  not in usart, so it should be okay to simply check for them along side the 168.
